### PR TITLE
update chart and Containerfile for ssmsend

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.1
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For the purposes of KAPEL this is the ssmsend version.
-appVersion: 3.3.1
+appVersion: 3.4.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -95,7 +95,7 @@ ssmsend:
   # Location of ssmsend container. Feel free to instead build your own using the provided Containerfile.
   image_repository: "git.computecanada.ca:4567/rptaylor/misc/ssmsend"
   # Optionally overwrite container version.
-  image_tag: "3.3.1"
+  image_tag: "3.4.1"
   host: "msg.argo.grnet.gr"
   # base64-encoded strings of the X509 public cert and private key for APEL publisher.
   # Using a base64 encoded string with no line breaks avoids issues of indentation and double YAML encoding if Ansible is used for Helm.

--- a/ssmsend-build/Containerfile
+++ b/ssmsend-build/Containerfile
@@ -1,11 +1,6 @@
-FROM registry.hub.docker.com/library/centos:7
+FROM registry.hub.docker.com/library/almalinux:9
 
-RUN yum update -y
-# EPEL is needed for python-dirq
-RUN yum install -y epel-release
-# UMD repo needed for python-argo-ams-library so APEL ssmsend can use AMS
-RUN yum install -y https://repository.egi.eu/sw/production/umd/4/centos7/x86_64/updates/umd-release-4.1.3-1.el7.centos.noarch.rpm
-# because UMD repo does not use HTTPS for GPG key
-RUN rpm --import https://repository.egi.eu/sw/production/umd/UMD-RPM-PGP-KEY
-RUN yum install -y python-dirq python-argo-ams-library https://github.com/apel/ssm/releases/download/3.3.1-1/apel-ssm-3.3.1-1.el7.noarch.rpm
-RUN yum clean all
+RUN dnf update -y
+RUN dnf install -y https://repository.egi.eu/sw/production/umd/5/al9/release/x86_64/umd-release-5.0.0-1.al9.alma.noarch.rpm
+RUN dnf install -y python3-dirq python3-argo-ams-library apel-ssm-3.4.1
+RUN dnf clean all


### PR DESCRIPTION
Use newer version of ssmsend that is supported and available on EL9, and update ssmsend container build file for EL9.

ssmsend release notes:
- https://github.com/apel/ssm/releases/tag/3.4.1-1
- https://github.com/apel/ssm/releases/tag/3.4.0-1