### PR TITLE
decouple image tag defaults from chart (app) versions

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -72,7 +72,7 @@ spec:
                 name: {{ .Release.Name }}-manual-records
           initContainers:
             - name: processor
-              image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag | default .Chart.Version }}
+              image: {{ .Values.processor.image_repository }}:{{ .Values.processor.image_tag }}
               imagePullPolicy: {{ .Values.processor.image_pull_policy }}
               workingDir: /src
               command: [ "python3" ]
@@ -119,7 +119,7 @@ spec:
           containers:
           {{ if eq .Values.outputFormat "gratia" }}
             - name: gratia-output
-              image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag | default .Chart.Version }}
+              image: {{ .Values.gratia.image_repository}}:{{ .Values.gratia.image_tag }}
               workingDir: /gratia
               command: [ "python3" ]
               args: [ "kubernetes_meter.py" ]
@@ -133,7 +133,7 @@ spec:
                   mountPath: /srv/kapel
           {{ else }}
             - name: ssmsend
-              image: {{ .Values.ssmsend.image_repository }}:{{ .Values.ssmsend.image_tag | default .Chart.AppVersion }}
+              image: {{ .Values.ssmsend.image_repository }}:{{ .Values.ssmsend.image_tag }}
               resources:
                 {{- toYaml .Values.ssmsend.resources | nindent 16 }}
               command: ["/bin/bash"]

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -48,8 +48,8 @@ containerSecurityContext:
 
 processor:
   image_repository: "hub.opensciencegrid.org/iris-hep/kuantifier-processor"
-  # Optionally overwrite container version. Default is chart appVersion.
-  image_tag: ""
+  # Optionally overwrite container version.
+  image_tag: "1.0.0"
   image_pull_policy: "IfNotPresent"
   resources:
     # very generous estimate: approx 10 KiB memory per job record
@@ -94,8 +94,8 @@ ssmsend:
   enabled: true
   # Location of ssmsend container. Feel free to instead build your own using the provided Containerfile.
   image_repository: "git.computecanada.ca:4567/rptaylor/misc/ssmsend"
-  # Optionally overwrite container version. Default is chart appVersion.
-  image_tag: ""
+  # Optionally overwrite container version.
+  image_tag: "3.3.1"
   host: "msg.argo.grnet.gr"
   # base64-encoded strings of the X509 public cert and private key for APEL publisher.
   # Using a base64 encoded string with no line breaks avoids issues of indentation and double YAML encoding if Ansible is used for Helm.
@@ -112,8 +112,8 @@ gratia:
       memory: "50Mi"
   # Location of gratia output container.
   image_repository: "hub.opensciencegrid.org/iris-hep/kuantifier-gratia-output"
-  # Optionally overwrite container version. Default is chart appVersion.
-  image_tag: ""
+  # Optionally overwrite container version.
+  image_tag: "1.0.0"
   # Config options for Gratia.
   config: 
     # Location of the Gratia probe config file. Can usually be kept as default


### PR DESCRIPTION
Change the image_tags so all the defaults are explicitly defined in values, instead of implicitly defaulting to the chart or app version.
This will decouple image tags from chart version and make it easier to update different components separately.

The actual default version numbers remain unchanged so there should be no change in behaviour.