### PR TITLE
Allow flexible ssmsend secret management via existingSecret

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.0
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/templates/cronjob.yaml
+++ b/chart/templates/cronjob.yaml
@@ -52,7 +52,7 @@ spec:
                 name: {{ .Release.Name }}-ssmsend-config
             - name: ssmsend-secret-volume
               secret:
-                secretName: {{ .Release.Name }}-ssmsend-secret
+                secretName: {{ .Values.ssmsend.existingSecret | default (printf "%s-ssmsend-secret" .Release.Name) }}
                 defaultMode: 0400
             {{ end }}
             {{ if .Values.gridSecurityHostPath }}

--- a/chart/templates/ssmsend-secret.yaml
+++ b/chart/templates/ssmsend-secret.yaml
@@ -1,4 +1,4 @@
-{{ if eq .Values.outputFormat "ssmsend" }}
+{{- if and (eq .Values.outputFormat "ssmsend") (not .Values.ssmsend.existingSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +9,4 @@ type: Opaque
 data:
   x509cert.pem: {{ .Values.ssmsend.x509cert }}
   x509key.pem: {{ .Values.ssmsend.x509key }}
-{{ end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -97,6 +97,10 @@ ssmsend:
   # Optionally overwrite container version.
   image_tag: "3.4.1"
   host: "msg.argo.grnet.gr"
+  # Provide the name of an existing secret containing x509cert.pem and x509key.pem.
+  # This is useful if managing secrets externally (e.g., with SealedSecrets).
+  # If this is set, x509cert and x509key below will be ignored.
+  existingSecret: ""
   # base64-encoded strings of the X509 public cert and private key for APEL publisher.
   # Using a base64 encoded string with no line breaks avoids issues of indentation and double YAML encoding if Ansible is used for Helm.
   x509cert: aW5zZXJ0IGJhc2U2NC1lbmNvZGVkIHN0cmluZyBvZiB0aGUgWDUwOSBwdWJsaWMgY2VydCBmb3IgQVBFTCBwdWJsaXNoZXIK


### PR DESCRIPTION
### Summary

This PR enhances the flexibility of managing the ssmsend X.509 certificate and key used for APEL publishing. Previously, the chart required the base64-encoded certificate and key to be provided directly in `values.yaml`, which could be cumbersome, especially when using external secret management systems like SealedSecrets with ArgoCD.

### Changes

1.  **Introduced `ssmsend.existingSecret`:** A new value in `values.yaml` allows specifying the name of a pre-existing Kubernetes Secret that contains the required `x509cert.pem` and `x509key.pem` data keys.
2.  **Conditional Secret Creation:** The `ssmsend-secret.yaml` template now only creates a Secret resource if `ssmsend.existingSecret` is *not* provided.
3.  **Updated Secret Usage:** The CronJob template (`cronjob.yaml`) now references the secret specified in `ssmsend.existingSecret` if it's set; otherwise, it defaults to the chart-managed secret (`<ReleaseName>-ssmsend-secret`).

### How to Use

*   **Option 1 (Use Existing Secret):**
    *   Create a Kubernetes Secret manually or using tools like SealedSecrets. Ensure it contains the data keys `x509cert.pem` and `x509key.pem` with the appropriate certificate and key data (base64 encoding is handled by Kubernetes).
    *   Set `ssmsend.existingSecret` in your `values.yaml` to the name of this secret.
    *   The values for `ssmsend.x509cert` and `ssmsend.x509key` will be ignored.
*   **Option 2 (Chart Creates Secret):**
    *   Leave `ssmsend.existingSecret` empty or remove it.
    *   Provide the base64-encoded certificate and key strings in `ssmsend.x509cert` and `ssmsend.x509key` respectively.

This change allows users to integrate the chart more seamlessly with existing secret management workflows while retaining the original method for simpler deployments.