### PR TITLE
Add support for deploying extra Kubernetes objects via `extraObjects` value

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.0
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/chart/README.md
+++ b/chart/README.md
@@ -64,7 +64,8 @@ below.
     * `BENCHMARK_VALUE`: The value to use for normalizing by CPU performance. Required for APEL accounting.
   * `.prometheus_auth`: If your Prometheus instance is configured to require [Authentication](https://prometheus.io/docs/prometheus/latest/configuration/https/)
     from within the cluster, specify a Secret containing a value for the authentication header.
- 
+* `.Values.extraObjects`: A list of additional Kubernetes objects to be deployed by the chart. Each item in the list should be a complete Kubernetes resource definition.
+
 #### Gratia Output Configuration
 
 The following values only apply if `.Values.outputFormat` equals `"gratia"`:

--- a/chart/templates/extra-objects.yaml
+++ b/chart/templates/extra-objects.yaml
@@ -1,4 +1,3 @@
----
 {{- if .Values.extraObjects }}
 {{- range $resource := .Values.extraObjects }}
 ---

--- a/chart/templates/extra-objects.yaml
+++ b/chart/templates/extra-objects.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.extraObjects }}
-{{- range $resource := .Values.extraObjects }}
+{{- range .Values.extraObjects }}
 ---
-{{ toYaml $resource }}
+{{- tpl (toYaml .) $ | nindent 0 }}
 {{- end }}
 {{- end }}

--- a/chart/templates/extra-objects.yaml
+++ b/chart/templates/extra-objects.yaml
@@ -1,0 +1,7 @@
+---
+{{- if .Values.extraObjects }}
+{{- range $resource := .Values.extraObjects }}
+---
+{{ toYaml $resource }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -126,3 +126,4 @@ gratia:
 
 nameOverride: ""
 fullnameOverride: ""
+extraObjects: []


### PR DESCRIPTION
This pull request introduces a new template, `chart/templates/extra-objects.yaml`, which enables the deployment of arbitrary Kubernetes resources alongside the main chart components.

Users can now define a list of Kubernetes resource manifests within the `extraObjects` key in their `values.yaml` file. The chart will iterate through this list and render each object, providing a flexible way to include custom resources, configurations, or dependencies needed for the application.

**Example Usage in `values.yaml`:**

```yaml
extraObjects:
  - apiVersion: bitnami.com/v1alpha1
    kind: SealedSecret
    metadata:
      creationTimestamp: null
      name: my-sealed-secret
      namespace: default # Or your target namespace
    spec:
      encryptedData:
        # Example: Replace with your actual encrypted data
        api-key: AgBy3i4OJSWK+PiTySYZZA9r5Ko1+eS4Q8k/VLAcCLsT9Nf+89/+5QZJpz78D/jQMAJq4t4JXTa9jPOtKBlq70aY7tOoK1/MYzzQu4zJ/zrLQNRO7aI43P+h2PEJW97x7SsDiVCMCU7F8rM/uP0f+P2TWjffP+V1E8P7pO6jY+X/l8lP9P0f3jZ+N/2k9P1i+l/0m+k/
        password: AgBy3i4OJSWK+PiTySYZZA9r5Ko1+eS4Q8k/VLAcCLsT9Nf+89/+5QZJpz78D/jQMAJq4t4JXTa9jPOtKBlq70aY7tOoK1/MYzzQu4zJ/zrLQNRO7aI43P+h2PEJW97x7SsDiVCMCU7F8rM/uP0f+P2TWjffP+V1E8P7pO6jY+X/l8lP9P0f3jZ+N/2k9P1i+l/0m+k/
      template:
        metadata:
          creationTimestamp: null
          name: my-sealed-secret
          namespace: default # Or your target namespace
        type: Opaque # Or the appropriate Secret type
```

