### PR TITLE
Update Prometheus auth to support authenticating via a kubernetes.io/service-account-token

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   kapel-processor:
-    image: hub.opensciencegrid.org/iris-hep/kuantifier-processor:1.0.0
+    image: hub.opensciencegrid.org/iris-hep/kuantifier-processor:1.0.1
     build:
       context: .
       network: host

--- a/python/KAPEL.py
+++ b/python/KAPEL.py
@@ -299,7 +299,7 @@ def record_individual_period(config, results):
 
 
 def get_auth_headers(config):
-    """ Check if an authentication secret has been configured via .Values.prometheus.auth,
+    """ Check if an authentication secret has been configured via .Values.processor.prometheus_auth
     and create an appropriate authentication header string if present
     """
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,5 @@ prometheus-api-client
 # For Prometheus API queries - not needed anymore if we use API lib instead
 #requests
 
+# For evaluating whether credentials are JWTs
+pyjwt[crypto]


### PR DESCRIPTION
@rptaylor we are working to get kuantifier running on an OpenShift cluster, which requires a `kubernetes.io/service-account-token`-typed Secret passed as the Bearer token into its Prometheus instance for auth. Our first pass of auth support just passed in an `Authentication` header directly from a secret value, this small PR updates it to prepend `Bearer` to the auth secret if it's a JWT.